### PR TITLE
 fix: temporary server.pid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       TZ: America/Sao_Paulo
     env_file:
       - .env
-    command: bash -c "bin/setup && rails s -b 0.0.0.0"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/setup && rails s -b 0.0.0.0"
 
   db:
     image: postgres:14.5


### PR DESCRIPTION
The purpose of this "pull request" is to solve the problem that sometimes happens when trying to start the project.

Below is a screenshot of the error:
![image](https://user-images.githubusercontent.com/85287720/233782235-cbf1f7e2-379d-4231-b939-036d1f8b0f34.png)


The suggested solution is to always remove "tmp/pids/server.pid" before trying to start the backend.
